### PR TITLE
Rename npm package to openwhisk-composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,10 @@ This repository includes:
 
 ## Installation
 
-Composer is distributed as Node.js package. The package is currently named `@ibm-functions/composer`,
-but will soon be available as `@openwhisk-composer`. Until we have our first official Apache release of
-composer, please continue to use the latest release of `@ibm-functions/composer`.
-To install this package, use the
+Composer is distributed as Node.js package. To install this package, use the
 Node Package Manager:
 ```
-npm install -g @ibm-functions/composer
+npm install -g openwhisk-composer
 ```
 We recommend to install the package globally (with `-g` option) if you intend to
 use the `compose` and `deploy` commands to compile and deploy compositions.
@@ -60,7 +57,7 @@ use the `compose` and `deploy` commands to compile and deploy compositions.
 A composition is typically defined by means of a Javascript expression as
 illustrated in [samples/demo.js](samples/demo.js):
 ```javascript
-const composer = require('@ibm-functions/composer')
+const composer = require('openwhisk-composer')
 
 module.exports = composer.if(
     composer.action('authenticate', { action: function ({ password }) { return { value: password === 'abc123' } } }),

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@ibm-functions/composer",
-  "version": "0.8.1",
+  "name": "openwhisk-composer",
+  "version": "0.9.0",
   "description": "Composer is a new programming model for composing cloud functions built on Apache OpenWhisk.",
-  "homepage": "https://github.com/ibm-functions/composer",
+  "homepage": "https://github.com/apache/incubator-openwhisk-composer",
   "main": "composer.js",
   "scripts": {
     "test": "standard && mocha"
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ibm-functions/composer.git"
+    "url": "https://github.com/apache/incubator-openwhisk-composer.git"
   },
   "keywords": [
     "functions",

--- a/samples/demo.js
+++ b/samples/demo.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const composer = require('@ibm-functions/composer')
+const composer = require('openwhisk-composer')
 
 module.exports = composer.if(
   composer.action('authenticate', { action: function ({ password }) { return { value: password === 'abc123' } } }),


### PR DESCRIPTION
- Rename npm package to `openwhisk-composer`.
- Bump version number to `0.9.0`.
- Update github urls.