### PR TITLE
Fix openwhisk-composer module resolution in compose command

### DIFF
--- a/bin/compose.js
+++ b/bin/compose.js
@@ -39,7 +39,7 @@ Module._resolveFilename = function (request, parent) {
     try {
       return _resolveFilename(request, parent)
     } catch (error) {
-      return require.resolve(request.replace(request.startsWith(json.name + '/') ? json.name : json.name.substring(0, json.name.indexOf('/')), '..'))
+      return require.resolve(request.replace(json.name, '..'))
     }
   } else {
     return _resolveFilename(request, parent)


### PR DESCRIPTION
The compose command now resolves the `openwhisk-composer` module to the parent folder if not found in the search path.