### PR TITLE
Add parallel, map, and dynamic combinators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ services:
 env:
   global:
     - IGNORE_CERTS=true
+    - REDIS=redis://172.17.0.1:6379
 before_install:
   - ./travis/scancode.sh
 before_script:

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ module.exports = composer.if(
     composer.action('failure', { action: function () { return { message: 'failure' } } }))
 ```
 Compositions compose actions using [combinator](docs/COMBINATORS.md) methods.
-These methods implement the typical control-flow constructs of a sequential
-imperative programming language. This example composition composes three actions
-named `authenticate`, `success`, and `failure` using the `composer.if`
-combinator, which implements the usual conditional construct. It take three
-actions (or compositions) as parameters. It invokes the first one and, depending
-on the result of this invocation, invokes either the second or third action.
+These methods implement the typical control-flow constructs of an imperative
+programming language. This example composition composes three actions named
+`authenticate`, `success`, and `failure` using the `composer.if` combinator,
+which implements the usual conditional construct. It take three actions (or
+compositions) as parameters. It invokes the first one and, depending on the
+result of this invocation, invokes either the second or third action.
 
  This composition includes the definitions of the three composed actions. If the
  actions are defined and deployed elsewhere, the composition code can be shorten
@@ -142,6 +142,49 @@ Compositions are implemented by means of OpenWhisk conductor actions. The
 [documentation of conductor
 actions](https://github.com/apache/incubator-openwhisk/blob/master/docs/conductors.md)
 explains execution traces in greater details.
+
+While composer does not limit in principle the length of a composition,
+OpenWhisk deployments typically enforce a limit on the number of action
+invocations in a composition as well as an upper bound on the rate of
+invocation. These limits may result in compositions failing to execute to
+completion.
+
+## Parallel compositions with Redis
+
+Composer offers parallel combinators that make it possible to run actions or
+compositions in parallel, for example:
+```javascript
+composer.parallel('checkInventory', 'detectFraud')
+```
+
+The width of parallel compositions is not in principle limited by composer, but
+issuing many concurrent invocations may hit OpenWhisk limits leading to
+failures: failure to execute a branch of a parallel composition or failure to
+complete the parallel composition.
+
+These combinators require access to a Redis instance to hold intermediate
+results of parallel compositions. The Redis credentials may be specified at
+invocation time or earlier by means of default parameters or package bindings.
+The required parameter is named `$composer`. It is a dictionary with a `redis`
+field of type dictionary. The `redis` dictionary specifies the `uri` for the
+Redis instance and optionally a certificate as a base64-encoded string to enable
+tls connections. Hence, the input parameter object for our order-processing
+example should be:
+```json
+{
+    "$composer": {
+        "redis": {
+            "uri": "redis://...",
+            "ca": "optional base64 encoded tls certificate"
+        }
+    },
+    "order": { ... }
+}
+```
+
+The intend is to use Redis only temporarily as the parallel composition is
+progressing. Keys are deleted after completion and, as an added safety, expire
+after twenty-four hours.
 
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ example should be:
 }
 ```
 
-The intend is to use Redis only temporarily as the parallel composition is
-progressing. Keys are deleted after completion and, as an added safety, expire
-after twenty-four hours.
+The intent is to store intermediate results in Redis as the parallel composition
+is progressing. Redis entries are deleted after completion and, as an added
+safety, expire after twenty-four hours.
 
 # Disclaimer
 

--- a/composer.js
+++ b/composer.js
@@ -285,7 +285,10 @@ const combinators = {
   mask: { components: true },
   action: { args: [{ name: 'name', type: 'name' }, { name: 'action', type: 'object', optional: true }] },
   function: { args: [{ name: 'function', type: 'object' }] },
-  async: { components: true }
+  async: { components: true },
+  parallel: { components: true },
+  map: { components: true },
+  dynamic: {}
 }
 
 Object.assign(composer, declare(combinators))
@@ -303,7 +306,8 @@ const extra = {
   retain_catch: { components: true, def: lowerer.retain_catch },
   value: { args: [{ name: 'value', type: 'value' }], def: lowerer.literal },
   literal: { args: [{ name: 'value', type: 'value' }], def: lowerer.literal },
-  merge: { components: true, def: lowerer.merge }
+  merge: { components: true, def: lowerer.merge },
+  par: { components: true, def: composer.parallel }
 }
 
 Object.assign(composer, declare(extra))

--- a/docs/COMPOSITIONS.md
+++ b/docs/COMPOSITIONS.md
@@ -25,12 +25,14 @@ _compositions_. An example composition is described in
 
 ## Control flow
 
-Compositions can express the control flow of typical a sequential imperative
-programming language: sequences, conditionals, loops, structured error handling.
-This control flow is specified using _combinator_ methods such as:
+Compositions can express the control flow of typical imperative programming
+language: sequences, conditionals, loops, structured error handling. This
+control flow is specified using _combinator_ methods such as:
 - `composer.sequence(firstAction, secondAction)`
 - `composer.if(conditionAction, consequentAction, alternateAction)`
 - `composer.try(bodyAction, handlerAction)`
+
+Parallel constructs are also available.
 
 Combinators are described in [COMBINATORS.md](COMBINATORS.md).
 

--- a/test/composer.js
+++ b/test/composer.js
@@ -414,4 +414,20 @@ describe('composer', function () {
   describe('composer.merge', function () {
     check('merge')
   })
+
+  describe('composer.parallel', function () {
+    check('parallel')
+  })
+
+  describe('composer.par', function () {
+    check('par')
+  })
+
+  describe('composer.map', function () {
+    check('map')
+  })
+
+  describe('composer.dynamic', function () {
+    check('dynamic', 0)
+  })
 })

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -50,6 +50,9 @@ $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD wipe.yml
 $ANSIBLE_CMD openwhisk.yml -e cli_installation_mode=remote -e limit_invocations_per_minute=600
 
+# Deploy Redis
+docker run -d -p 6379:6379 --name redis redis:4.0
+
 # Log configuration
 docker images
 docker ps


### PR DESCRIPTION
This PR adds support for parallel composition in composer with two combinators:
- composer.parallel or composer.par runs a series of compositions in parallel on the same input;
- composer.map runs multiple instances of a composition in parallel on different inputs.

This PR also adds the composer.dynamic combinator to make it possible to compute the name of an action to invoke at run time.

The implementation of the parallel combinators require read/write access to a Redis instance.