### PR TITLE
Add debug setting to control needle options

### DIFF
--- a/bin/compose.js
+++ b/bin/compose.js
@@ -24,6 +24,7 @@ const Module = require('module')
 const path = require('path')
 
 const argv = minimist(process.argv.slice(2), {
+  string: ['debug'],
   boolean: ['version', 'ast', 'js'],
   alias: { version: 'v' }
 })
@@ -54,6 +55,7 @@ if (argv._.length !== 1 || path.extname(argv._[0]) !== '.js') {
   console.error('  --ast                  only output the ast for the composition')
   console.error('  --js                   output the conductor action code for the composition')
   console.error('  -v, --version          output the composer version')
+  console.error('  --debug LIST           comma-separated list of debug flags (when using --js flag)')
   process.exit(1)
 }
 
@@ -67,7 +69,7 @@ try {
   process.exit(422 - 256) // Unprocessable Entity
 }
 if (argv.js) {
-  console.log(conductor.generate(composition).action.exec.code)
+  console.log(conductor.generate(composition, argv.debug).action.exec.code)
 } else {
   if (argv.ast) composition = composition.ast
   console.log(JSON.stringify(composition, null, 4))


### PR DESCRIPTION
Example:
```
deploy demo ~/demo.json -w --debug 'needle<{"connection":"keep-alive","open_timeout":60000}>'
```

Needle options are specified as a json object and delimited by `needle<` and `>`.

To turn on needle logging and specify options the following is needed:
```
deploy demo ~/demo.json -w --debug 'needle,needle<{"connection":"keep-alive","open_timeout":60000}>'
```

These options are relevant to spawning new compositions using the `async`, `parallel`, `par`, and `map` combinators.

Invalid options are ignored but recorded with a log entry.